### PR TITLE
adding correction grid and test

### DIFF
--- a/em_stitch/utils/utils.py
+++ b/em_stitch/utils/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 import json
+import renderapi
 
 
 def get_z_from_metafile(metafile):
@@ -58,6 +59,31 @@ def src_from_xy(x, y, transpose=True):
     if not transpose:
         return src
     return src.transpose()
+
+
+def correction_grid(transform, npts=20):
+    """create src and dst for a thinplatespline transform
+    Parameters
+    ----------
+    transform : renderapi.transform.ThinPlateSplineTransform
+        or <>.to_dict() result of said transform
+
+    Returns
+    -------
+    src : numpy array
+        Nx2 where N = npts**2. linearly sampled grid
+    dst : numpy array
+        Nx2. The result of transform.tform(src)
+    """
+
+    if isinstance(transform, dict):
+        transform = renderapi.transform.ThinPlateSplineTransform(
+                json=transform)
+    xymax = transform.srcPts.max(axis=1)
+    src = src_from_xy(
+            np.linspace(0, xymax[0], npts),
+            np.linspace(0, xymax[1], npts))
+    return src, transform.tform(src)
 
 
 def pointmatch_filter(

--- a/integration_tests/test_utils.py
+++ b/integration_tests/test_utils.py
@@ -1,0 +1,29 @@
+from em_stitch.utils.utils import correction_grid
+import json
+import renderapi
+import os
+import glob
+import numpy as np
+
+test_files_dir = os.path.join(os.path.dirname(__file__), 'test_files')
+
+
+def test_correction_grid():
+    data_dir = os.path.join(test_files_dir, "montage_example")
+    meta = glob.glob(os.path.join(
+        data_dir, '_metadata*.json'))[0]
+    with open(meta, 'r') as f:
+        j = json.load(f)
+    jtform = j[2]['sharedTransform']
+
+    npts = 20
+    src, dst = correction_grid(jtform, npts=npts)
+    delta = dst - src
+    mag = np.linalg.norm(delta, axis=1)
+    assert mag.size == npts**2
+
+    tf = renderapi.transform.ThinPlateSplineTransform(json=jtform)
+    src, dst = correction_grid(tf, npts=npts)
+    delta = dst - src
+    mag = np.linalg.norm(delta, axis=1)
+    assert mag.size == npts**2


### PR DESCRIPTION
@jaybo 
I added a function you can use to get information about the transform, like so:

```
from em_stitch.utils import utils as emu
import json
import numpy as np

with open('/data/em-131fs3/lctest/T3.2019.04.24.a/20190424083337_reference/0/lens_correction_transform.json', 'r') as f:
    jtform = json.load(f)

# or, you already have jtform in memory ...

src, dst = emu.correction_grid(jtform)
delta = dst - src
mag = np.linalg.norm(delta, axis=1)

print('average magnitude : %0.2fpx' % mag.mean())
print('max magnitude : %0.2fpx' % mag.max())
print('average x : %0.2fpx' % delta[:, 0].mean())
print('average |x| : %0.2fpx' % np.abs(delta[:, 0]).mean())
print('max |x| : %0.2fpx' % np.abs(delta[:, 0]).max())
print('etc.')
```
should give you this:
```
average magnitude : 18.89px
max magnitude : 81.22px
average x : 0.65px
average |x| : 14.08px
max |x| : 77.90px
etc.
```