### PR TITLE
pinning argschema to 1.17.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argschema
+argschema==1.17.5
 render-python>=2.2.0
 numpy>=1.13
 scipy>=1.2.1


### PR DESCRIPTION
now that there is argschema 2.0.1 as release, this repo is not ready for it yet