### PR TITLE
Requirements update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+test-reports/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+.vscode
+
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-argschema==1.17.5
+marshmallow<3.0
+argschema<2.0
 render-python>=2.2.0
 numpy>=1.13
 scipy>=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.13
 scipy>=1.2.1
 triangle
 bigfeta>=1.0.3
+opencv-python

--- a/setup.py
+++ b/setup.py
@@ -22,32 +22,12 @@ class PyTest(TestCommand):
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
-def opencv_mess():
-    ver = None
-    try:
-        import cv2
-        r = cv2.xfeatures2d
-        ver = cv2.__version__
-    except ImportError:
-        # no opencv is installed, we don't need contrib
-        required = 'opencv-python<=3.4.5'
-    except AttributeError:
-        # someone has opencv installed (but not contrib)
-        # let's require some version
-        required = 'opencv-python<=3.4.5'
-    if ver:
-        # opencv-contrib-python is installed
-        # let's require some version
-        required = 'opencv-contrib-python<3.4.3.0'
-    return required
-
 
 with open('test_requirements.txt', 'r') as f:
     test_required = f.read().splitlines()
 
 with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()
-    required.append(opencv_mess())
 
 setup(name='em_stitch',
       use_scm_version=True,
@@ -59,4 +39,3 @@ setup(name='em_stitch',
       install_requires=required,
       tests_require=test_required,
       cmdclass={'test': PyTest})
-

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+mccabe<0.7.0,>=0.6.0
 coverage>=4.1
 mock>=2.0.0
 pep8>=1.7.0


### PR DESCRIPTION
Eases argschema and opencv requirements to match asap and adds a `.gitignore`.

opencv-python now contains SIFT, so the whole alignment stack has lost the contrib requirement.