### PR TITLE
bugfix: bincount counting errors in some use cases

### DIFF
--- a/em_stitch/lens_correction/mesh_and_solve_transform.py
+++ b/em_stitch/lens_correction/mesh_and_solve_transform.py
@@ -468,7 +468,7 @@ def count_points_near_vertices(
         v_touches.append(flat_ind[np.argwhere(flat_tri == i)])
     found = t.find_simplex(coords, bruteforce=bruteforce_simplex_counts)
     if count_bincount:
-        bc = np.bincount(found)
+        bc = np.bincount(found, minlength=t.nsimplex)
         pt_count = np.array([
             bc[v_touches[i]].sum() for i in range(t.npoints)
         ])


### PR DESCRIPTION
bincount has optional minlength argument to extend bins past the extent of the input array.  In some use cases (like asap test_coarse_mesh_failure) this was causing an indexerror as the last value was not included in the bincount.